### PR TITLE
fix issue with description not respecting line breaks

### DIFF
--- a/src/popup/bookmark.js
+++ b/src/popup/bookmark.js
@@ -256,9 +256,9 @@ App.registerPanel(P_DETAILS, {
   },
 
   populateForm() {
-    this._titleInput.value           = this._payload.data.attributes.title
-    this._tagsInput.value            = this._payload.data.attributes.tags.join(", ")
-    this._descriptionInput.innerText = this._payload.data.attributes.description
+    this._titleInput.value             = this._payload.data.attributes.title
+    this._tagsInput.value              = this._payload.data.attributes.tags.join(", ")
+    this._descriptionInput.textContent = this._payload.data.attributes.description
   },
 
   // This method is called when the panel is about to be shown.


### PR DESCRIPTION
This should fix the issue where line breaks in a description would: not be displayed properly when the popup was reshown and when the bookmark was resaved with this incorrectly displayed description, it would get persisted to the transientBug service as well.